### PR TITLE
Let this crate use the stm32f4xx-hal instead of stm32f4 directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,12 @@ authors = ["Adam Greig <adam@adamgreig.com>"]
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.5.7"
+cortex-m = "0.5.8"
 
 [dependencies.smoltcp]
 version = "0.5.0"
 default-features = false
 features = ["proto-ipv4"]
 
-[dependencies.stm32f4]
-version = "0.3.2"
-features = ["stm32f407"]
+[dependencies.stm32f4xx-hal]
+version = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,18 @@ impl EthernetDevice {
         }
     }
 
+    /// Enable receive interrupt
+    pub fn enable_rx_interrupt(&mut self) {
+        self.eth_dma
+            .dmaier
+            .modify(|_, w| w.nise().set_bit().rie().set_bit());
+    }
+
+    /// Disable receive interrupt
+    pub fn disable_rx_interrupt(&mut self) {
+        self.eth_dma.dmaier.modify(|_, w| w.rie().clear_bit());
+    }
+
     /// Sets up the device peripherals.
     fn init_peripherals(&mut self, mac: EthernetAddress) {
         cortex_m::interrupt::free(|_| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
 #![no_std]
-#![feature(min_const_fn)]
 
-use stm32f4::stm32f407;
-use smoltcp::{self, phy::{self, DeviceCapabilities}, time::Instant, wire::EthernetAddress};
+pub extern crate stm32f4xx_hal as hal;
+use self::hal::stm32::{ETHERNET_DMA, ETHERNET_MAC, RCC};
+
+use smoltcp::{
+    self,
+    phy::{self, DeviceCapabilities},
+    time::Instant,
+    wire::EthernetAddress,
+};
 
 pub const ETH_BUF_SIZE: usize = 1536;
 
@@ -15,8 +21,8 @@ pub const ETH_BUF_SIZE: usize = 1536;
 ///
 /// Note that Copy and Clone are derived to support initialising an array of TDes,
 /// but you may not move a TDes after its address has been given to the ETH_DMA engine.
-#[derive(Copy,Clone)]
-#[repr(C,packed)]
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
 pub struct TDes {
     tdes0: u32,
     tdes1: u32,
@@ -26,13 +32,18 @@ pub struct TDes {
 
 impl TDes {
     pub const fn new() -> TDes {
-        TDes { tdes0: 0, tdes1: 0, tdes2: 0, tdes3: 0 }
+        TDes {
+            tdes0: 0,
+            tdes1: 0,
+            tdes2: 0,
+            tdes3: 0,
+        }
     }
 
     /// Initialises this TDes to point at the given buffer.
     pub fn init(&mut self, tdbuf: &[u32]) {
         // Set FS and LS on each descriptor: each will hold a single full segment.
-        self.tdes0 = (1<<29) | (1<<28);
+        self.tdes0 = (1 << 29) | (1 << 28);
         // Store pointer to associated buffer.
         self.tdes2 = tdbuf.as_ptr() as u32;
         // No second buffer.
@@ -41,17 +52,17 @@ impl TDes {
 
     /// Mark this TDes as end-of-ring.
     pub fn set_end_of_ring(&mut self) {
-        self.tdes0 |= 1<<21;
+        self.tdes0 |= 1 << 21;
     }
 
     /// Return true if the RDes is not currently owned by the DMA
     pub fn available(&self) -> bool {
-        self.tdes0 & (1<<31) == 0
+        self.tdes0 & (1 << 31) == 0
     }
 
     /// Release this RDes back to DMA engine for transmission
     pub unsafe fn release(&mut self) {
-        self.tdes0 |= 1<<31;
+        self.tdes0 |= 1 << 31;
     }
 
     /// Set the length of data in the buffer pointed to by this TDes
@@ -60,7 +71,7 @@ impl TDes {
     }
 
     /// Access the buffer pointed to by this descriptor
-    pub unsafe fn buf_as_slice_mut(&self) -> &mut [u8] {
+    pub unsafe fn buf_as_slice_mut(&mut self) -> &mut [u8] {
         core::slice::from_raw_parts_mut(self.tdes2 as *mut _, self.tdes1 as usize & 0x1FFF)
     }
 }
@@ -68,7 +79,7 @@ impl TDes {
 /// Store a ring of TDes and associated buffers
 pub struct TDesRing<'a> {
     pub td: &'a mut [TDes],
-    pub tbuf: &'a mut [[u32; ETH_BUF_SIZE/4]],
+    pub tbuf: &'a mut [[u32; ETH_BUF_SIZE / 4]],
     pub tdidx: usize,
 }
 
@@ -116,8 +127,8 @@ impl<'a> TDesRing<'a> {
 ///
 /// Note that Copy and Clone are derived to support initialising an array of TDes,
 /// but you may not move a TDes after its address has been given to the ETH_DMA engine.
-#[derive(Copy,Clone)]
-#[repr(C,packed)]
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
 pub struct RDes {
     rdes0: u32,
     rdes1: u32,
@@ -127,13 +138,18 @@ pub struct RDes {
 
 impl RDes {
     pub const fn new() -> RDes {
-        RDes { rdes0: 0, rdes1: 0, rdes2: 0, rdes3: 0 }
+        RDes {
+            rdes0: 0,
+            rdes1: 0,
+            rdes2: 0,
+            rdes3: 0,
+        }
     }
 
     /// Initialises this RDes to point at the given buffer.
     pub fn init(&mut self, rdbuf: &[u32]) {
         // Mark each RDes as owned by the DMA engine.
-        self.rdes0 = 1<<31;
+        self.rdes0 = 1 << 31;
         // Store length of and pointer to associated buffer.
         self.rdes1 = rdbuf.len() as u32 * 4;
         self.rdes2 = rdbuf.as_ptr() as u32;
@@ -143,17 +159,17 @@ impl RDes {
 
     /// Mark this RDes as end-of-ring.
     pub fn set_end_of_ring(&mut self) {
-        self.rdes1 |= 1<<15;
+        self.rdes1 |= 1 << 15;
     }
 
     /// Return true if the RDes is not currently owned by the DMA
     pub fn available(&self) -> bool {
-        self.rdes0 & (1<<31) == 0
+        self.rdes0 & (1 << 31) == 0
     }
 
     /// Release this RDes back to the DMA engine
     pub unsafe fn release(&mut self) {
-        self.rdes0 |= 1<<31;
+        self.rdes0 |= 1 << 31;
     }
 
     /// Access the buffer pointed to by this descriptor
@@ -165,7 +181,7 @@ impl RDes {
 /// Store a ring of RDes and associated buffers
 pub struct RDesRing<'a> {
     pub rd: &'a mut [RDes],
-    pub rbuf: &'a mut [[u32; ETH_BUF_SIZE/4]],
+    pub rbuf: &'a mut [[u32; ETH_BUF_SIZE / 4]],
     pub rdidx: usize,
 }
 
@@ -208,8 +224,8 @@ impl<'a> RDesRing<'a> {
 pub struct EthernetDevice {
     rdring: &'static mut RDesRing<'static>,
     tdring: &'static mut TDesRing<'static>,
-    eth_mac: stm32f407::ETHERNET_MAC,
-    eth_dma: stm32f407::ETHERNET_DMA,
+    eth_mac: ETHERNET_MAC,
+    eth_dma: ETHERNET_DMA,
     phy_addr: u8,
 }
 
@@ -219,11 +235,20 @@ impl EthernetDevice {
     /// You must move in ETH_MAC, ETH_DMA, and they are then kept by the device.
     ///
     /// You may only call this function once; subsequent calls will panic.
-    pub fn new(eth_mac: stm32f407::ETHERNET_MAC, eth_dma: stm32f407::ETHERNET_DMA,
-               rdring: &'static mut RDesRing, tdring: &'static mut TDesRing,
-               phy_addr: u8)
-    -> EthernetDevice {
-        EthernetDevice { rdring, tdring, eth_mac, eth_dma, phy_addr }
+    pub fn new(
+        eth_mac: ETHERNET_MAC,
+        eth_dma: ETHERNET_DMA,
+        rdring: &'static mut RDesRing,
+        tdring: &'static mut TDesRing,
+        phy_addr: u8,
+    ) -> EthernetDevice {
+        EthernetDevice {
+            rdring,
+            tdring,
+            eth_mac,
+            eth_dma,
+            phy_addr,
+        }
     }
 
     /// Initialise the ethernet driver.
@@ -232,18 +257,18 @@ impl EthernetDevice {
     /// and configures the ETH MAC and DMA peripherals.
     ///
     /// Brings up the PHY and then blocks waiting for a network link.
-    pub fn init(&mut self, rcc: &mut stm32f407::RCC, addr: EthernetAddress) {
+    pub fn init(&mut self, addr: EthernetAddress) {
         self.tdring.init();
         self.rdring.init();
 
-        self.init_peripherals(rcc, addr);
+        self.init_peripherals(addr);
 
         self.phy_reset();
         self.phy_init();
     }
 
     pub fn link_established(&mut self) -> bool {
-        return self.phy_poll_link()
+        return self.phy_poll_link();
     }
 
     pub fn block_until_link(&mut self) {
@@ -265,60 +290,80 @@ impl EthernetDevice {
     }
 
     /// Sets up the device peripherals.
-    fn init_peripherals(&mut self, rcc: &mut stm32f407::RCC, mac: EthernetAddress) {
-        // Reset ETH_MAC and ETH_DMA
-        rcc.ahb1rstr.modify(|_, w| w.ethmacrst().reset());
-        rcc.ahb1rstr.modify(|_, w| w.ethmacrst().clear_bit());
+    fn init_peripherals(&mut self, mac: EthernetAddress) {
+        cortex_m::interrupt::free(|_| {
+            let rcc = unsafe { &(*RCC::ptr()) };
+
+            // Reset ETH_MAC and ETH_DMA
+            rcc.ahb1rstr.modify(|_, w| w.ethmacrst().reset());
+            rcc.ahb1rstr.modify(|_, w| w.ethmacrst().clear_bit());
+        });
+
         self.eth_dma.dmabmr.modify(|_, w| w.sr().reset());
         while self.eth_dma.dmabmr.read().sr().is_reset() {}
 
         // Set MAC address
         let mac = mac.as_bytes();
-        self.eth_mac.maca0lr.write(|w| w.maca0l().bits(
-            (mac[0] as u32) << 0 | (mac[1] as u32) << 8 |
-            (mac[2] as u32) <<16 | (mac[3] as u32) <<24));
-        self.eth_mac.maca0hr.write(|w| w.maca0h().bits(
-            (mac[4] as u16) << 0 | (mac[5] as u16) << 8));
+        self.eth_mac.maca0lr.write(|w| {
+            w.maca0l().bits(
+                (mac[0] as u32) << 0
+                    | (mac[1] as u32) << 8
+                    | (mac[2] as u32) << 16
+                    | (mac[3] as u32) << 24,
+            )
+        });
+        self.eth_mac
+            .maca0hr
+            .write(|w| w.maca0h().bits((mac[4] as u16) << 0 | (mac[5] as u16) << 8));
 
         // Enable RX and TX. We'll set link speed and duplex at link-up.
-        self.eth_mac.maccr.write(|w|
-            w.re().enabled()
-             .te().enabled()
-             .cstf().enabled()
-        );
+        self.eth_mac
+            .maccr
+            .write(|w| w.re().enabled().te().enabled().cstf().enabled());
 
         // Tell the ETH DMA the start of each ring
-        self.eth_dma.dmatdlar.write(|w| w.stl().bits(self.tdring.ptr() as u32));
-        self.eth_dma.dmardlar.write(|w| w.srl().bits(self.rdring.ptr() as u32));
+        self.eth_dma
+            .dmatdlar
+            .write(|w| w.stl().bits(self.tdring.ptr() as u32));
+        self.eth_dma
+            .dmardlar
+            .write(|w| w.srl().bits(self.rdring.ptr() as u32));
 
         // Set DMA bus mode
-        self.eth_dma.dmabmr.modify(|_, w|
-            w.aab().aligned()
-             .pbl().pbl1()
-        );
+        self.eth_dma
+            .dmabmr
+            .modify(|_, w| w.aab().aligned().pbl().pbl1());
 
         // Flush TX FIFO
         self.eth_dma.dmaomr.write(|w| w.ftf().flush());
         while self.eth_dma.dmaomr.read().ftf().is_flush() {}
 
         // Set DMA operation mode to store-and-forward and start DMA
-        self.eth_dma.dmaomr.write(|w|
-            w.rsf().store_forward()
-             .tsf().store_forward()
-             .st().started()
-             .sr().started()
-        );
+        self.eth_dma.dmaomr.write(|w| {
+            w.rsf()
+                .store_forward()
+                .tsf()
+                .store_forward()
+                .st()
+                .started()
+                .sr()
+                .started()
+        });
     }
 
     /// Read a register over SMI.
     fn smi_read(&mut self, reg: u8) -> u16 {
         // Use PHY address 00000, set register address, set clock to HCLK/102, start read.
-        self.eth_mac.macmiiar.write(|w|
-            w.mb().busy()
-             .pa().bits(self.phy_addr)
-             .cr().cr_150_168()
-             .mr().bits(reg)
-        );
+        self.eth_mac.macmiiar.write(|w| {
+            w.mb()
+                .busy()
+                .pa()
+                .bits(self.phy_addr)
+                .cr()
+                .cr_150_168()
+                .mr()
+                .bits(reg)
+        });
 
         // Wait for read
         while self.eth_mac.macmiiar.read().mb().is_busy() {}
@@ -332,26 +377,31 @@ impl EthernetDevice {
         // Use PHY address 00000, set write data, set register address, set clock to HCLK/102,
         // start write operation.
         self.eth_mac.macmiidr.write(|w| w.md().bits(val));
-        self.eth_mac.macmiiar.write(|w|
-            w.mb().busy()
-             .pa().bits(self.phy_addr)
-             .mw().write()
-             .cr().cr_150_168()
-             .mr().bits(reg)
-        );
+        self.eth_mac.macmiiar.write(|w| {
+            w.mb()
+                .busy()
+                .pa()
+                .bits(self.phy_addr)
+                .mw()
+                .write()
+                .cr()
+                .cr_150_168()
+                .mr()
+                .bits(reg)
+        });
 
         while self.eth_mac.macmiiar.read().mb().is_busy() {}
     }
 
     /// Reset the connected PHY and wait for it to come out of reset.
     fn phy_reset(&mut self) {
-        self.smi_write(0x00, 1<<15);
-        while self.smi_read(0x00) & (1<<15) == (1<<15) {}
+        self.smi_write(0x00, 1 << 15);
+        while self.smi_read(0x00) & (1 << 15) == (1 << 15) {}
     }
 
     /// Command connected PHY to initialise.
     fn phy_init(&mut self) {
-        self.smi_write(0x00, 1<<12);
+        self.smi_write(0x00, 1 << 12);
     }
 
     /// Poll PHY to determine link status.
@@ -361,21 +411,30 @@ impl EthernetDevice {
         let lpa = self.smi_read(0x05);
 
         // No link without autonegotiate
-        if bcr & (1<<12) == 0 { return false; }
+        if bcr & (1 << 12) == 0 {
+            return false;
+        }
         // No link if link is down
-        if bsr & (1<< 2) == 0 { return false; }
+        if bsr & (1 << 2) == 0 {
+            return false;
+        }
         // No link if remote fault
-        if bsr & (1<< 4) != 0 { return false; }
+        if bsr & (1 << 4) != 0 {
+            return false;
+        }
         // No link if autonegotiate incomplete
-        if bsr & (1<< 5) == 0 { return false; }
+        if bsr & (1 << 5) == 0 {
+            return false;
+        }
         // No link if other side can't do 100Mbps full duplex
-        if lpa & (1<< 8) == 0 { return false; }
+        if lpa & (1 << 8) == 0 {
+            return false;
+        }
 
         // Got link. Configure MAC to 100Mbit/s and full duplex.
-        self.eth_mac.maccr.modify(|_, w|
-            w.fes().fes100()
-             .dm().full_duplex()
-        );
+        self.eth_mac
+            .maccr
+            .modify(|_, w| w.fes().fes100().dm().full_duplex());
 
         true
     }
@@ -386,7 +445,8 @@ pub struct RxToken(*mut EthernetDevice);
 
 impl phy::TxToken for TxToken {
     fn consume<R, F>(self, _timestamp: Instant, len: usize, f: F) -> smoltcp::Result<R>
-        where F: FnOnce(&mut [u8]) -> smoltcp::Result<R>
+    where
+        F: FnOnce(&mut [u8]) -> smoltcp::Result<R>,
     {
         // There can only be a single EthernetDevice and therefore all TxTokens are wrappers
         // to a raw pointer to it. Unsafe required to dereference this pointer and call
@@ -405,7 +465,8 @@ impl phy::TxToken for TxToken {
 
 impl phy::RxToken for RxToken {
     fn consume<R, F>(self, _timestamp: Instant, f: F) -> smoltcp::Result<R>
-        where F: FnOnce(&[u8]) -> smoltcp::Result<R>
+    where
+        F: FnOnce(&[u8]) -> smoltcp::Result<R>,
     {
         // There can only be a single EthernetDevice and therefore all RxTokens are wrappers
         // to a raw pointer to it. Unsafe required to dereference this pointer and call
@@ -428,8 +489,7 @@ impl<'a> phy::Device<'a> for EthernetDevice {
     fn capabilities(&self) -> DeviceCapabilities {
         let mut caps = DeviceCapabilities::default();
         caps.max_transmission_unit = 1500;
-        caps.max_burst_size = Some(core::cmp::min(
-            self.rdring.rd.len(), self.tdring.td.len()));
+        caps.max_burst_size = Some(core::cmp::min(self.rdring.rd.len(), self.tdring.td.len()));
         caps
     }
 


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>